### PR TITLE
fix require path (can't be camel case)

### DIFF
--- a/lib/livingstyleguide.rb
+++ b/lib/livingstyleguide.rb
@@ -34,5 +34,5 @@ class String
   end
 end
 
-require 'LivingStyleGuide/integration'
+require 'livingstyleguide/integration'
 


### PR DESCRIPTION
with the camel case I got the following error:

```
`require': cannot load such file -- LivingStyleGuide/integration (LoadError)
```
