### PR TITLE
Fix undefined mixin hide-text: import compass

### DIFF
--- a/stylesheets/_livingstyleguide.scss
+++ b/stylesheets/_livingstyleguide.scss
@@ -48,6 +48,8 @@ $livingstyleguide--highlight-border-radius: 2px;
 
 //// IMPORTS ////
 
+@import "compass";
+
 @import "livingstyleguide/layout";
 @import "livingstyleguide/content";
 @import "livingstyleguide/code";


### PR DESCRIPTION
`_layout.scss` and `_color-swatches.scss` depend on compass and thus fail to compile if used in a project that does not already import compass through its specified stylesheet source.
