### PR TITLE
Ignore duplicate @import directives in Sass

### DIFF
--- a/lib/livingstyleguide/engine.rb
+++ b/lib/livingstyleguide/engine.rb
@@ -137,6 +137,8 @@ module LivingStyleGuide
         next unless sass_filename.is_a?(String)
         glob = "#{sass_filename.sub(/\.s[ac]ss$/, '')}.md"
         Dir.glob(glob) do |markdown_filename|
+          next if files.include?(markdown_filename)
+
           files << markdown_filename
           @markdown << File.read(markdown_filename)
         end
@@ -209,4 +211,3 @@ module LivingStyleGuide
   end
 
 end
-

--- a/test/fixtures/standalone/style-dup-imports.scss
+++ b/test/fixtures/standalone/style-dup-imports.scss
@@ -1,0 +1,5 @@
+$my-base-color: green;
+
+@import "compass";
+@import "modules/buttons";
+@import "modules/buttons";

--- a/test/fixtures/standalone/styleguide-dup-imports.html.lsg
+++ b/test/fixtures/standalone/styleguide-dup-imports.html.lsg
@@ -1,0 +1,2 @@
+source: "style-dup-imports.scss"
+title: "My Nice & Beautiful Living Style Guide"

--- a/test/integration/standalone_test.rb
+++ b/test/integration/standalone_test.rb
@@ -72,10 +72,14 @@ class MarkdownTest < Minitest::Test
     assert_match %r(\.\\\$some-map), html
   end
 
+  def test_duplicate_imports_rendered_once
+    html = render('test/fixtures/standalone/styleguide-dup-imports.html.lsg')
+    assert_equal 1, html.scan(%r(<h2 class="livingstyleguide--headline" id="buttons")).size
+  end
+
   private
   def render(file)
     Tilt.new(file).render.gsub(/\s+/, ' ')
   end
 
 end
-


### PR DESCRIPTION
Append Markdown for rendering only once per unique Sass source file.
