### PR TITLE
NoMethodError when using image-url

### DIFF
--- a/lib/livingstyleguide/tilt_template.rb
+++ b/lib/livingstyleguide/tilt_template.rb
@@ -40,6 +40,9 @@ module LivingStyleGuide
       options[:syntax]    = @options[:syntax]
       options[:sprockets] = { context: @scope }
       options[:custom]    = { sprockets_context: @scope }
+      if defined?(Sass::Rails)
+        options[:custom][:resolver] = Sass::Rails::Resolver.new(@scope)
+      end
       options
     end
 


### PR DESCRIPTION
When using `image-url` in my imported stylesheets (in a Rails app) I am getting the following exception:

```
Started GET "/assets/styleguide.html" for 127.0.0.1 at 2014-12-04 08:15:14 +0100
Error compiling asset styleguide.html:
NoMethodError: undefined method `image_path' for nil:NilClass
  (in /Users/frederikfix/src/konvenit/stylator/assets/stylesheets/styleguide.html.lsg)

NoMethodError (undefined method `image_path' for nil:NilClass
  (in /Users/frederikfix/src/konvenit/stylator/assets/stylesheets/styleguide.html.lsg)):
  sass-rails (3.2.5) lib/sass/rails/helpers.rb:25:in `image_url'
  sass (3.4.9) lib/sass/script/tree/funcall.rb:139:in `_perform'
  sass (3.4.9) lib/sass/script/tree/node.rb:50:in `perform'
  sass (3.4.9) lib/sass/script/tree/list_literal.rb:62:in `block in _perform'
  sass (3.4.9) lib/sass/script/tree/list_literal.rb:62:in `map'
  sass (3.4.9) lib/sass/script/tree/list_literal.rb:62:in `_perform'
  sass (3.4.9) lib/sass/script/tree/node.rb:50:in `perform'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:384:in `visit_prop'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block (2 levels) in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `map'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:179:in `with_environment'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:418:in `visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block (2 levels) in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `map'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:179:in `with_environment'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:418:in `visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block (2 levels) in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `map'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:420:in `block in visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:179:in `with_environment'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:418:in `visit_rule'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `block (2 levels) in visit_import'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `map'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `block in visit_import'
  sass (3.4.9) lib/sass/stack.rb:88:in `block in with_import'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:88:in `with_import'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:312:in `visit_import'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `block (2 levels) in visit_import'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `map'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:315:in `block in visit_import'
  sass (3.4.9) lib/sass/stack.rb:88:in `block in with_import'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:88:in `with_import'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:312:in `visit_import'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `block in visit'
  sass (3.4.9) lib/sass/stack.rb:79:in `block in with_base'
  sass (3.4.9) lib/sass/stack.rb:115:in `with_frame'
  sass (3.4.9) lib/sass/stack.rb:79:in `with_base'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:158:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:52:in `block in visit_children'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:52:in `map'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:52:in `visit_children'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:167:in `block in visit_children'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:179:in `with_environment'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:166:in `visit_children'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `block in visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:186:in `visit_root'
  sass (3.4.9) lib/sass/tree/visitors/base.rb:36:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:157:in `visit'
  sass (3.4.9) lib/sass/tree/visitors/perform.rb:8:in `visit'
  sass (3.4.9) lib/sass/tree/root_node.rb:36:in `css_tree'
  sass (3.4.9) lib/sass/tree/root_node.rb:20:in `render'
  sass (3.4.9) lib/sass/engine.rb:268:in `render'
  livingstyleguide (1.2.0) lib/livingstyleguide/engine.rb:56:in `css'
  livingstyleguide (1.2.0) lib/livingstyleguide/engine.rb:166:in `css'
  (erb):14:in `get_binding'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/lib/ruby/1.9.1/erb.rb:838:in `eval'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/lib/ruby/1.9.1/erb.rb:838:in `result'
  livingstyleguide (1.2.0) lib/livingstyleguide/engine.rb:145:in `template'
  livingstyleguide (1.2.0) lib/livingstyleguide/engine.rb:27:in `render'
  livingstyleguide (1.2.0) lib/livingstyleguide/tilt_template.rb:92:in `render_living_style_guide'
  livingstyleguide (1.2.0) lib/livingstyleguide/tilt_template.rb:16:in `evaluate'
  tilt (1.4.1) lib/tilt/template.rb:103:in `render'
  sprockets (2.2.3) lib/sprockets/context.rb:193:in `block in evaluate'
  sprockets (2.2.3) lib/sprockets/context.rb:190:in `each'
  sprockets (2.2.3) lib/sprockets/context.rb:190:in `evaluate'
  sprockets (2.2.3) lib/sprockets/processed_asset.rb:12:in `initialize'
  sprockets (2.2.3) lib/sprockets/base.rb:249:in `new'
  sprockets (2.2.3) lib/sprockets/base.rb:249:in `block in build_asset'
  sprockets (2.2.3) lib/sprockets/base.rb:270:in `circular_call_protection'
  sprockets (2.2.3) lib/sprockets/base.rb:248:in `build_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:93:in `block in build_asset'
  sprockets (2.2.3) lib/sprockets/caching.rb:19:in `cache_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:92:in `build_asset'
  sprockets (2.2.3) lib/sprockets/base.rb:169:in `find_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:60:in `find_asset'
  sprockets (2.2.3) lib/sprockets/bundled_asset.rb:16:in `initialize'
  sprockets (2.2.3) lib/sprockets/base.rb:252:in `new'
  sprockets (2.2.3) lib/sprockets/base.rb:252:in `build_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:93:in `block in build_asset'
  sprockets (2.2.3) lib/sprockets/caching.rb:19:in `cache_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:92:in `build_asset'
  sprockets (2.2.3) lib/sprockets/base.rb:169:in `find_asset'
  sprockets (2.2.3) lib/sprockets/index.rb:60:in `find_asset'
  sprockets (2.2.3) lib/sprockets/environment.rb:78:in `find_asset'
  sprockets (2.2.3) lib/sprockets/server.rb:47:in `call'
  journey (1.0.4) lib/journey/router.rb:68:in `block in call'
  journey (1.0.4) lib/journey/router.rb:56:in `each'
  journey (1.0.4) lib/journey/router.rb:56:in `call'
  actionpack (3.2.21) lib/action_dispatch/routing/route_set.rb:608:in `call'
  rack (1.4.5) lib/rack/etag.rb:23:in `call'
  rack (1.4.5) lib/rack/conditionalget.rb:25:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/head.rb:14:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/params_parser.rb:21:in `call'
  rack (1.4.5) lib/rack/session/abstract/id.rb:210:in `context'
  rack (1.4.5) lib/rack/session/abstract/id.rb:205:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/cookies.rb:341:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/callbacks.rb:28:in `block in call'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `_run__2606029308286811569__call__2017298591965270755__callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:405:in `__run_callback'
  activesupport (3.2.21) lib/active_support/callbacks.rb:385:in `_run_call_callbacks'
  activesupport (3.2.21) lib/active_support/callbacks.rb:81:in `run_callbacks'
  actionpack (3.2.21) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/remote_ip.rb:31:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/debug_exceptions.rb:16:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/show_exceptions.rb:56:in `call'
  railties (3.2.21) lib/rails/rack/logger.rb:32:in `call_app'
  railties (3.2.21) lib/rails/rack/logger.rb:16:in `block in call'
  activesupport (3.2.21) lib/active_support/tagged_logging.rb:22:in `tagged'
  railties (3.2.21) lib/rails/rack/logger.rb:16:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/request_id.rb:22:in `call'
  rack (1.4.5) lib/rack/methodoverride.rb:21:in `call'
  rack (1.4.5) lib/rack/runtime.rb:17:in `call'
  activesupport (3.2.21) lib/active_support/cache/strategy/local_cache.rb:72:in `call'
  actionpack (3.2.21) lib/action_dispatch/middleware/static.rb:83:in `call'
  railties (3.2.21) lib/rails/engine.rb:484:in `call'
  railties (3.2.21) lib/rails/application.rb:231:in `call'
  railties (3.2.21) lib/rails/railtie/configurable.rb:30:in `method_missing'
  thin (1.6.3) lib/thin/connection.rb:86:in `block in pre_process'
  thin (1.6.3) lib/thin/connection.rb:84:in `catch'
  thin (1.6.3) lib/thin/connection.rb:84:in `pre_process'
  thin (1.6.3) lib/thin/connection.rb:53:in `process'
  thin (1.6.3) lib/thin/connection.rb:39:in `receive_data'
  eventmachine (1.0.3) lib/eventmachine.rb:187:in `run_machine'
  eventmachine (1.0.3) lib/eventmachine.rb:187:in `run'
  thin (1.6.3) lib/thin/backends/base.rb:73:in `start'
  thin (1.6.3) lib/thin/server.rb:162:in `start'
  thin (1.6.3) lib/thin/controllers/controller.rb:87:in `start'
  thin (1.6.3) lib/thin/runner.rb:200:in `run_command'
  thin (1.6.3) lib/thin/runner.rb:156:in `run!'
  thin (1.6.3) bin/thin:6:in `<top (required)>'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/bin/thin:23:in `load'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/bin/thin:23:in `<main>'
```

My gem versions are:
- actionpack (3.2.21)
- livingstyleguide (1.2.0)
- sass (3.4.9)
- sass-rails (3.2.5)
- sprockets (2.2.3)

I tracked the error down to this line:
https://github.com/rails/sass-rails/blob/3.2.5/lib/sass/rails/helpers.rb#L32

In a standalone SASS stylesheet compilation this entry is set here:
https://github.com/rails/sass-rails/blob/3.2.5/lib/sass/rails/template_handlers.rb#L93

The attached pull request emulates that behaviour and fixes the exception for me.
