### PR TITLE
fix breakage with sass-rails > 5.0 (see #105)

### DIFF
--- a/lib/livingstyleguide/tilt_template.rb
+++ b/lib/livingstyleguide/tilt_template.rb
@@ -40,7 +40,7 @@ module LivingStyleGuide
       options[:syntax]    = @options[:syntax]
       options[:sprockets] = { context: @scope }
       options[:custom]    = { sprockets_context: @scope }
-      if defined?(Sass::Rails)
+      if defined?(Sass::Rails::Resolver)
         options[:custom][:resolver] = Sass::Rails::Resolver.new(@scope)
       end
       options


### PR DESCRIPTION
In #105 it is reported that the commit 59c7724 breaks when using sass-rails > 5.0

Two possible backtraces can be found. Either the one in the issue above, or the one below
```
NameError (uninitialized constant Sass::Rails::Resolver
  (in /Users/frederikfix/src/prog/r41/app/assets/stylesheets/styleguide.html.lsg)):
  livingstyleguide (1.2.1) lib/livingstyleguide/tilt_template.rb:44:in `sass_options'
  livingstyleguide (1.2.1) lib/livingstyleguide/tilt_template.rb:94:in `render_living_style_guide'
  livingstyleguide (1.2.1) lib/livingstyleguide/tilt_template.rb:16:in `evaluate'
  tilt (1.4.1) lib/tilt/template.rb:103:in `render'
  sprockets (2.12.3) lib/sprockets/context.rb:197:in `block in evaluate'
  sprockets (2.12.3) lib/sprockets/context.rb:194:in `each'
  sprockets (2.12.3) lib/sprockets/context.rb:194:in `evaluate'
  sprockets (2.12.3) lib/sprockets/processed_asset.rb:12:in `initialize'
  sprockets (2.12.3) lib/sprockets/base.rb:374:in `new'
  sprockets (2.12.3) lib/sprockets/base.rb:374:in `block in build_asset'
  sprockets (2.12.3) lib/sprockets/base.rb:395:in `circular_call_protection'
  sprockets (2.12.3) lib/sprockets/base.rb:373:in `build_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:94:in `block in build_asset'
  sprockets (2.12.3) lib/sprockets/caching.rb:58:in `cache_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:93:in `build_asset'
  sprockets (2.12.3) lib/sprockets/base.rb:287:in `find_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:61:in `find_asset'
  sprockets (2.12.3) lib/sprockets/bundled_asset.rb:16:in `initialize'
  sprockets (2.12.3) lib/sprockets/base.rb:377:in `new'
  sprockets (2.12.3) lib/sprockets/base.rb:377:in `build_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:94:in `block in build_asset'
  sprockets (2.12.3) lib/sprockets/caching.rb:58:in `cache_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:93:in `build_asset'
  sprockets (2.12.3) lib/sprockets/base.rb:287:in `find_asset'
  sprockets (2.12.3) lib/sprockets/index.rb:61:in `find_asset'
  sprockets (2.12.3) lib/sprockets/environment.rb:75:in `find_asset'
  sprockets (2.12.3) lib/sprockets/server.rb:47:in `call'
  actionpack (4.1.6) lib/action_dispatch/journey/router.rb:73:in `block in call'
  actionpack (4.1.6) lib/action_dispatch/journey/router.rb:59:in `each'
  actionpack (4.1.6) lib/action_dispatch/journey/router.rb:59:in `call'
  actionpack (4.1.6) lib/action_dispatch/routing/route_set.rb:678:in `call'
  rack (1.5.2) lib/rack/etag.rb:23:in `call'
  rack (1.5.2) lib/rack/conditionalget.rb:25:in `call'
  rack (1.5.2) lib/rack/head.rb:11:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/params_parser.rb:27:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/flash.rb:254:in `call'
  rack (1.5.2) lib/rack/session/abstract/id.rb:225:in `context'
  rack (1.5.2) lib/rack/session/abstract/id.rb:220:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/cookies.rb:560:in `call'
  activerecord (4.1.6) lib/active_record/query_cache.rb:36:in `call'
  activerecord (4.1.6) lib/active_record/connection_adapters/abstract/connection_pool.rb:621:in `call'
  activerecord (4.1.6) lib/active_record/migration.rb:380:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/callbacks.rb:29:in `block in call'
  activesupport (4.1.6) lib/active_support/callbacks.rb:82:in `run_callbacks'
  actionpack (4.1.6) lib/action_dispatch/middleware/callbacks.rb:27:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/reloader.rb:73:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/remote_ip.rb:76:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/debug_exceptions.rb:17:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/show_exceptions.rb:30:in `call'
  railties (4.1.6) lib/rails/rack/logger.rb:38:in `call_app'
  railties (4.1.6) lib/rails/rack/logger.rb:20:in `block in call'
  activesupport (4.1.6) lib/active_support/tagged_logging.rb:68:in `block in tagged'
  activesupport (4.1.6) lib/active_support/tagged_logging.rb:26:in `tagged'
  activesupport (4.1.6) lib/active_support/tagged_logging.rb:68:in `tagged'
  railties (4.1.6) lib/rails/rack/logger.rb:20:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/request_id.rb:21:in `call'
  rack (1.5.2) lib/rack/methodoverride.rb:21:in `call'
  rack (1.5.2) lib/rack/runtime.rb:17:in `call'
  activesupport (4.1.6) lib/active_support/cache/strategy/local_cache_middleware.rb:26:in `call'
  rack (1.5.2) lib/rack/lock.rb:17:in `call'
  actionpack (4.1.6) lib/action_dispatch/middleware/static.rb:64:in `call'
  rack (1.5.2) lib/rack/sendfile.rb:112:in `call'
  railties (4.1.6) lib/rails/engine.rb:514:in `call'
  railties (4.1.6) lib/rails/application.rb:144:in `call'
  rack (1.5.2) lib/rack/lock.rb:17:in `call'
  rack (1.5.2) lib/rack/content_length.rb:14:in `call'
  rack (1.5.2) lib/rack/handler/webrick.rb:60:in `service'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/lib/ruby/1.9.1/webrick/httpserver.rb:138:in `service'
  /Users/frederikfix/.rbenv/versions/1.9.3-p547/lib/ruby/1.9.1/webrick/httpserver.rb:94:in `run'
```


