### PR TITLE
Never pass explicit nil to Tilt::Template#render

### DIFF
--- a/lib/livingstyleguide/document.rb
+++ b/lib/livingstyleguide/document.rb
@@ -95,7 +95,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
         require "tilt/#{template_name}"
       rescue LoadError
       end
-      engine.new{ remove_highlights(result) }.render(@scope, @locals.merge(locals))
+      engine.new{ remove_highlights(result) }.render(@scope || Object.new, @locals.merge(locals))
     elsif @type == :escaped
       ERB::Util.h(remove_highlights(result))
     else
@@ -249,7 +249,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
         sass_options[:load_paths] << path
       end
     end
-    scss_template.new(file, sass_options){ scss }.render(@scope)
+    scss_template.new(file, sass_options){ scss }.render(@scope || Object.new)
   end
 end
 


### PR DESCRIPTION
Workaround for test failures on Ruby 2.2.

Here's a reduced test case:

```ruby
require 'tilt'

t = Tilt::HamlTemplate.new do
  '%h1'
end
p t.render(nil)
```

**Output: Ruby 2.1**:
```
<h1></h1>
```

**Output: Ruby 2.2**:
```
(__TEMPLATE__):4:in `ensure in block in singleton class': undefined method `upper' for nil:NilClass (NoMethodError)
	from (__TEMPLATE__):4:in `block in singleton class'
	from (__TEMPLATE__):-9:in `instance_eval'
	from (__TEMPLATE__):-9:in `singleton class'
	from (__TEMPLATE__):-11:in `__tilt_70265677939160'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:155:in `call'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:155:in `evaluate'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/haml.rb:17:in `evaluate'
	from /Users/alexbcoles/.gem/ruby/2.2.0/gems/tilt-2.0.1/lib/tilt/template.rb:96:in `render'
	from test_case.rb:15:in `<main>'
```