### PR TITLE
Fix bug with the search-box

### DIFF
--- a/stylesheets/livingstyleguide/_search.scss
+++ b/stylesheets/livingstyleguide/_search.scss
@@ -4,5 +4,5 @@
 }
 
 .lsg--search-box {
-  margin: 2 * $lsg--gap-width $lsg--width + ($lsg--width / 4);
+  margin: (2 * $lsg--gap-width) 0 0 ($lsg--width + ($lsg--width / 4));
 }


### PR DESCRIPTION
We have noticed a little bug with the search-box margin values:

![](https://www.evernote.com/l/AjZBAAt2qTNGX7FAyfNECkzFCyuHKJGV0I4B/image.png)


After this fix, the result is the following: 

![](https://www.evernote.com/l/AjY33jQAXm9O3JmTrPJwFkuPI7xktaCYTaIB/image.png)