### PR TITLE
Add require statement in sass filter.

### DIFF
--- a/lib/livingstyleguide/filters/sass.rb
+++ b/lib/livingstyleguide/filters/sass.rb
@@ -1,3 +1,5 @@
+require 'sass'
+
 LivingStyleGuide.add_filter :scss do |arguments, options, scss|
   file = arguments.first
   if file


### PR DESCRIPTION
When we use the sass filter in a style guide: 

```markdown
# HELLO WORLD

@sass
  body
    background-color: pink
```

An error is generated:

```
$ bundle exec livingstyleguide compile sass.lsg sass.html
/Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/livingstyleguide-2.0.0.alpha.10/lib/livingstyleguide/filters/sass.rb:24:in `block in <top (required)>': uninitialized constant Sass (NameError)
    from (erb):5:in `get_binding'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/2.1.0/erb.rb:850:in `eval'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/2.1.0/erb.rb:850:in `result'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/livingstyleguide-2.0.0.alpha.10/lib/livingstyleguide/document.rb:94:in `evaluate'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/tilt-2.0.1/lib/tilt/template.rb:96:in `render'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/livingstyleguide-2.0.0.alpha.10/lib/livingstyleguide/command_line_interface.rb:12:in `compile'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/command.rb:27:in `run'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/invocation.rb:126:in `invoke_command'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor.rb:359:in `dispatch'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/thor-0.19.1/lib/thor/base.rb:440:in `start'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/gems/livingstyleguide-2.0.0.alpha.10/bin/livingstyleguide:15:in `<top (required)>'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bin/livingstyleguide:23:in `load'
    from /Users/Anyelina/.rbenv/versions/2.1.5/lib/ruby/gems/2.1.0/bin/livingstyleguide:23:in `<main>'
```