### PR TITLE
Change width > max-width for $livingstyleguide--width

### DIFF
--- a/stylesheets/livingstyleguide/_code.scss
+++ b/stylesheets/livingstyleguide/_code.scss
@@ -75,7 +75,7 @@
   display: block;//none;
   line-height: $livingstyleguide--code-line-height;
   padding: 3px 6px;
-  width: $livingstyleguide--width;
+  max-width: $livingstyleguide--width;
 
   .show-code & {
     display: block;
@@ -98,7 +98,7 @@
   .livingstyleguide--code {
     display: block;
     margin: auto;
-    width: $livingstyleguide--width;
+    max-width: $livingstyleguide--width;
   }
 }
 

--- a/stylesheets/livingstyleguide/_color-swatches.scss
+++ b/stylesheets/livingstyleguide/_color-swatches.scss
@@ -38,7 +38,7 @@
   margin: $livingstyleguide--gap-width auto (-$livingstyleguide--gap-width) auto;
   overflow: hidden;
   padding-left: $livingstyleguide--gap-width;
-  width: $livingstyleguide--width + 2 * $livingstyleguide--gap-width;
+  max-width: $livingstyleguide--width + 2 * $livingstyleguide--gap-width;
 }
 
 @for $i from 1 through 12 {

--- a/stylesheets/livingstyleguide/_content.scss
+++ b/stylesheets/livingstyleguide/_content.scss
@@ -10,7 +10,7 @@
   line-height: $livingstyleguide--base-line-height;
   margin: $livingstyleguide--gap-width auto;
   text-align: $livingstyleguide--base-text-align;
-  width: $livingstyleguide--width;
+  max-width: $livingstyleguide--width;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -35,7 +35,7 @@
   line-height: $livingstyleguide--headline-line-height;
   margin: (3 * $livingstyleguide--gap-width) auto $livingstyleguide--gap-width;
   text-align: $livingstyleguide--headline-text-align;
-  width: $livingstyleguide--width;
+  max-width: $livingstyleguide--width;
   -webkit-font-smoothing: antialiased;
 }
 
@@ -89,7 +89,7 @@
   overflow: hidden;
   padding: $livingstyleguide--gap-width;
   position: relative;
-  width: $livingstyleguide--width;
+  max-width: $livingstyleguide--width;
 
   &.-lsg-has-full-width {
     @extend #{$livingstyleguide--layout-selector} !optional;
@@ -99,7 +99,7 @@
     margin: 0 auto;
     min-height: auto;
     padding: $livingstyleguide--full-width-padding;
-    width: 100%;
+    max-width: none;
   }
 
   &.-lsg-for-javascript {

--- a/stylesheets/livingstyleguide/_layout.scss
+++ b/stylesheets/livingstyleguide/_layout.scss
@@ -14,7 +14,7 @@
   @extend %livingstyleguide--reset;
   display: block;
   margin: (4 * $livingstyleguide--gap-width) auto;
-  width: $livingstyleguide--width;
+  max-width: $livingstyleguide--width;
 }
 
 .livingstyleguide--logo {


### PR DESCRIPTION
To make the livingstyleguide more responsive, it makes sense to make the width declaration max-width instead of width. As it currently stands, width means that if the window is smaller than 640px, the elements with `width: $livingstyleguide--width` will stick out and make the livingstyleguide look broken.

Changing this to max-width keeps the same effect for when there's more than 640px available, but also means it doesn't break for smaller screens.

As a result of this change, I've changed `width: 100%` for the `.-lsg-has-full-width` class to `max-width: none`, to cancel our our max width.

From what I can see the individual color swatches may need a bit of work to make them responsive too, as I'm not sure if they're set up to break into multiple levels.

As this is used to document responsive websites, it's great for the styleguide to be responsive too to allow this.

Great work with LSG, thanks for making it :thumbs-up: