### PR TITLE
fixes #204 can not be use the URL string to `@javascript-before` syntax

### DIFF
--- a/lib/livingstyleguide/document.rb
+++ b/lib/livingstyleguide/document.rb
@@ -232,7 +232,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
     arguments.map! do |argument|
       argument.strip!
       argument.gsub! "\\;", ";"
-      if /^(?<key>[a-zA-Z0-9_\-]+):(?<value>.+)$/ =~ argument
+      if /^(?!https?:)(?<key>[a-zA-Z0-9_\-]+):(?<value>.+)$/ =~ argument
         options[key.downcase.tr("-", "_").to_sym] = remove_quots(value.strip)
         nil
       else

--- a/lib/livingstyleguide/document.rb
+++ b/lib/livingstyleguide/document.rb
@@ -232,7 +232,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
     arguments.map! do |argument|
       argument.strip!
       argument.gsub! "\\;", ";"
-      if /^(?!https?:)(?<key>[a-zA-Z0-9_\-]+):(?<value>.+)$/ =~ argument
+      if /^(?<key>[a-zA-Z0-9_\-]+):(?<value>.+)$/ =~ argument
         options[key.downcase.tr("-", "_").to_sym] = remove_quots(value.strip)
         nil
       else

--- a/test/unit/commands/layout_test.rb
+++ b/test/unit/commands/layout_test.rb
@@ -48,7 +48,7 @@ class HtmlHeadTest < DocumentTestCase
 
   def test_javascript_before
     assert_render_match <<-INPUT, <<-OUTPUT, template: "layout"
-      @javascript-before https://code.jquery.com/jquery-3.1.0.min.js
+      @javascript-before "https://code.jquery.com/jquery-3.1.0.min.js"
       @javascript-before application.js
       @javascript-before {
         alert("Hello World!");
@@ -62,7 +62,7 @@ class HtmlHeadTest < DocumentTestCase
 
   def test_javascript_after
     assert_render_match <<-INPUT, <<-OUTPUT, template: "layout"
-      @javascript-after https://code.jquery.com/jquery-3.1.0.min.js
+      @javascript-after "https://code.jquery.com/jquery-3.1.0.min.js"
       @javascript-after application.js
       @javascript-after {
         alert("Good Bye World!");

--- a/test/unit/commands/layout_test.rb
+++ b/test/unit/commands/layout_test.rb
@@ -48,6 +48,7 @@ class HtmlHeadTest < DocumentTestCase
 
   def test_javascript_before
     assert_render_match <<-INPUT, <<-OUTPUT, template: "layout"
+      @javascript-before https://code.jquery.com/jquery-3.1.0.min.js
       @javascript-before application.js
       @javascript-before {
         alert("Hello World!");
@@ -55,12 +56,13 @@ class HtmlHeadTest < DocumentTestCase
       @javascript-before transpiler: coffee-script
         alert "Hello Coffee World!"
     INPUT
-      <head>.*<script src="application.js"><\/script> <script> alert\\("Hello World!"\\); <\/script> <script>.+alert\\("Hello Coffee World!"\\);.*<\/script>.*</head>
+      <head>.*<script src="https://code.jquery.com/jquery-3.1.0.min.js"><\/script> <script src="application.js"><\/script> <script> alert\\("Hello World!"\\); <\/script> <script>.+alert\\("Hello Coffee World!"\\);.*<\/script>.*</head>
     OUTPUT
   end
 
   def test_javascript_after
     assert_render_match <<-INPUT, <<-OUTPUT, template: "layout"
+      @javascript-after https://code.jquery.com/jquery-3.1.0.min.js
       @javascript-after application.js
       @javascript-after {
         alert("Good Bye World!");
@@ -68,7 +70,7 @@ class HtmlHeadTest < DocumentTestCase
       @javascript-after transpiler: coffee-script
         alert "Good Bye Coffee World!"
     INPUT
-      <body.*<script src="application.js"><\/script> <script> alert\\("Good Bye World!"\\); <\/script> <script>.+alert\\("Good Bye Coffee World!"\\);.*<\/script>.*</body>
+      <body.*<script src="https://code.jquery.com/jquery-3.1.0.min.js"><\/script> <script src="application.js"><\/script> <script> alert\\("Good Bye World!"\\); <\/script> <script>.+alert\\("Good Bye Coffee World!"\\);.*<\/script>.*</body>
     OUTPUT
   end
 

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -127,6 +127,17 @@ describe LivingStyleGuide::Document do
         OUTPUT
       end
 
+      it "can have filters with an url argument" do
+        LivingStyleGuide.command :my_url_filter do |arguments, options, block|
+          "arg: #{arguments.first}"
+        end
+        assert_document_equal <<-INPUT, <<-OUTPUT, type: :plain
+          @my-url-filter http://code.jquery.com/jquery-3.1.0.min.js
+        INPUT
+          arg: http://code.jquery.com/jquery-3.1.0.min.js
+        OUTPUT
+      end
+
     end
 
     describe "filters with blocks in braces" do

--- a/test/unit/document_test.rb
+++ b/test/unit/document_test.rb
@@ -132,7 +132,7 @@ describe LivingStyleGuide::Document do
           "arg: #{arguments.first}"
         end
         assert_document_equal <<-INPUT, <<-OUTPUT, type: :plain
-          @my-url-filter http://code.jquery.com/jquery-3.1.0.min.js
+          @my-url-filter "http://code.jquery.com/jquery-3.1.0.min.js"
         INPUT
           arg: http://code.jquery.com/jquery-3.1.0.min.js
         OUTPUT


### PR DESCRIPTION
fixes #204 can not be use the URL string(ex. http://examole.com/js.js) to `@javascript-before` syntax

Secondarily also fixes for the case of `@javascript-after` syntax