### PR TITLE
Prevent plain examples to be parsed

### DIFF
--- a/lib/livingstyleguide/document.rb
+++ b/lib/livingstyleguide/document.rb
@@ -210,6 +210,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
   end
 
   def parse_commands
+    return data if type == :plain
     doc = (data || "").gsub("<%", "<%%")
     doc.gsub(/\G(?<content>.*?)(?<code_block>(?:```.+?```)|\Z)/m) do
       content = $~[:content]


### PR DESCRIPTION
Hi Nico,

I experienced weird behavior with an example like

``````
```plain
@include prefix(dirty) {
    color: red;
}    
```
``````

that got parsed due to the `@import` line. I'd expect plain code examples not to be parsed at all.

Obv, this would be a breaking change, tho.

Alternatively, adding a hint to the readme on the possibility to do escape sequences would be helful I guess. Like, the above leads to an error, whilst the following renders fine:

``````
```plain
\@include prefix(dirty) {
    color: red;
}    
```
``````
