### PR TITLE
Require ActiveSupport::Deprecation for slug method

### DIFF
--- a/lib/livingstyleguide/markdown_extensions.rb
+++ b/lib/livingstyleguide/markdown_extensions.rb
@@ -70,6 +70,7 @@ module LivingStyleGuide
 
     def slug(text)
       require "active_support/core_ext/string/inflections"
+      require "active_support/deprecation"
       ::ActiveSupport::Inflector.parameterize(text, "-")
     rescue LoadError
       text.downcase.gsub(/[ _\.\-!\?\(\)\[\]]+/, "-").gsub(/^-|-$/, "")


### PR DESCRIPTION
This commit adds a require statement for the `ActiveSupport::Deprecation` class before trying to call the `ActiveSupport::Inflector#parameterize` from `LivingStyleGuide::RedcarpetHTML#slug`. Without this additional require an error is raised when using Rails `5.0.0.1`:

```ruby
$ livingstyleguide compile app/assets/stylesheets/styleguide.lsg public/styleguide.html
.rbenv/versions/2.3.1/lib/ruby/gems/2.3.0/gems/activesupport-5.0.0.1/lib/active_support/inflector/transliterate.rb:84:in `parameterize': 
uninitialized constant ActiveSupport::Deprecation (NameError)
```

Rails `5.0.0.1` adds a deprecation warning within the `ActiveSupport::Inflector#parameterize` method for the `separator` positional argument, which is being replaced with a keyword argument `separator:`. The `LivingStyleGuide::RedcarpetHTML#slug` method uses the deprecated positional `separator` argument.

The error is raised because we only require `active_support/core_ext/string/inflections` which does not in turn require `active_support/deprecation`. I am wondering if this should be addressed in rails itself?

I would have updated the `slug` method to use the new keyword argument for `separator` but this would break the gem for users on earlier versions of rails. Let me know if you would like a PR for that breaking change instead / as-well :+1:

Useful links:

- [ActiveSupport::Inflector#parameterize](https://github.com/rails/rails/blob/v5.0.0.1/activesupport/lib/active_support/inflector/transliterate.rb#L84) on Rails `5.0.0.1` branch
