### PR TITLE
Sprockets require

### DIFF
--- a/lib/livingstyleguide/commands/sass.rb
+++ b/lib/livingstyleguide/commands/sass.rb
@@ -11,7 +11,6 @@ LivingStyleGuide.command :scss do |arguments, options, scss|
     document.depend_on file
     document.scss << %Q(@import "#{file}";\n)
   elsif options[:sprockets] && defined?(Rails) && defined?(Rails::Railtie) && defined?(Sprockets)
-    #if defined?(Rails) && defined?(Rails::Railtie) && defined?(Sprockets)
     css = Rails.application.assets.find_asset(options[:sprockets]).source
     document.scss << css
   else

--- a/lib/livingstyleguide/commands/sass.rb
+++ b/lib/livingstyleguide/commands/sass.rb
@@ -8,8 +8,11 @@ LivingStyleGuide.command :scss do |arguments, options, scss|
     if document.file
       file = File.join(File.dirname(document.file), file)
     end
-    css = Rails.application.assets.find_asset(arguments.first).source
     document.depend_on file
+    document.scss << %Q(@import "#{file}";\n)
+  elsif options[:sprockets] && defined?(Rails) && defined?(Rails::Railtie) && defined?(Sprockets)
+    #if defined?(Rails) && defined?(Rails::Railtie) && defined?(Sprockets)
+    css = Rails.application.assets.find_asset(options[:sprockets]).source
     document.scss << css
   else
     id = document.id.gsub(/[\/\.]/, '\\\\\0')

--- a/lib/livingstyleguide/commands/sass.rb
+++ b/lib/livingstyleguide/commands/sass.rb
@@ -8,8 +8,9 @@ LivingStyleGuide.command :scss do |arguments, options, scss|
     if document.file
       file = File.join(File.dirname(document.file), file)
     end
+    css = Rails.application.assets.find_asset(arguments.first).source
     document.depend_on file
-    document.scss << %Q(@import "#{file}";\n)
+    document.scss << css
   else
     id = document.id.gsub(/[\/\.]/, '\\\\\0')
     document.scss << "##{id} {\n#{scss}\n}\n"


### PR DESCRIPTION
for rails projects, that use `*= require` instead of `@import` 

can be invoked using: `@scss sprockets: site/application.css.scss`
if it needs tests or other changes let me know.

