### PR TITLE
Use kwargs syntax for parameterize

### DIFF
--- a/lib/livingstyleguide/markdown_extensions.rb
+++ b/lib/livingstyleguide/markdown_extensions.rb
@@ -70,7 +70,11 @@ module LivingStyleGuide
 
     def slug(text)
       require "active_support/core_ext/string/inflections"
-      ::ActiveSupport::Inflector.parameterize(text, "-")
+      if ::ActiveSupport::VERSION::MAJOR >= 5
+        ::ActiveSupport::Inflector.parameterize(text, separator: "-")
+      else
+        ::ActiveSupport::Inflector.parameterize(text, "-")
+      end
     rescue LoadError
       text.downcase.gsub(/[ _\.\-!\?\(\)\[\]]+/, "-").gsub(/^-|-$/, "")
     end


### PR DESCRIPTION
This causes a deprecation warning on up to Rails 5.0, and will cause errors on 5.1.0 due to this change in upstream rails:

https://github.com/rails/rails/commit/0189f4db6fe518de8909b66b7f30046bac52dedc

This fixes #214. There is a discussion ongoing in this issue to replace the inflector since this line seems to be the only dependency to it. We only use livingstyleguide in the context of rails however, so this doesn't really matter to us.