### PR TITLE
Using Tilt[scss] as the scss_template

### DIFF
--- a/lib/livingstyleguide/document.rb
+++ b/lib/livingstyleguide/document.rb
@@ -293,7 +293,7 @@ class LivingStyleGuide::Document < ::Tilt::Template
   end
 
   def scss_template
-    ::LivingStyleGuide.default_options[:scss_template] || Tilt["scss"]
+    Tilt["scss"]
   end
 
   def render_scss(scss)

--- a/lib/livingstyleguide/integration/rails.rb
+++ b/lib/livingstyleguide/integration/rails.rb
@@ -5,8 +5,6 @@ if defined?(Rails) && defined?(Rails::Railtie) && defined?(Sprockets)
       Rails.application.config.assets.configure do |env|
         LivingStyleGuideTransformer.register(env)
       end
-      LivingStyleGuide.default_options[:scss_template] =
-        ::SassC::Rails::ScssTemplate
       app.config.assets.paths << ::LivingStyleGuide::SASS_PATH
     end
   end

--- a/test/unit/commands/import_and_use_test.rb
+++ b/test/unit/commands/import_and_use_test.rb
@@ -102,8 +102,6 @@ class ImportAndSourceTest < DocumentTestCase
       .*?
       <h2.+?>Bar Bar</h2>
       .*?
-      <h2.+?>Headline</h2>
-      .*?
       <p.+?>After</p>
     OUTPUT
   end


### PR DESCRIPTION
## Why

- The 2.1.0 doesn't work with the new SassC version (Rails 6.0)

- Resolve #233 

- Resolve #234 

## What happened

Using the **Tilt[scss]** as the **scss_template**

## Insight

Currently, the new **sassc-rails** version doesn't rely on Tilt anymore, [it relies on Sprockets::SassProcessor]( https://github.com/sass/sassc-rails/blob/master/lib/sassc/rails/template.rb#L8), it's another dependency so our gem doesn't work anymore.

On the previous **sass-rails** version, the SassTemplate is [inherited from the Tilt::Template](https://github.com/rails/sass-rails/blob/5-0-8/lib/sass/rails/template.rb#L9)

![image](https://user-images.githubusercontent.com/11751745/67505619-d126b880-f6b5-11e9-95e4-cba23eac30b9.png)


## Proof Of Work

**Before**

<img width="1421" alt="Screen Shot 2019-10-24 at 23 07 29" src="https://user-images.githubusercontent.com/11751745/67505131-e6e7ae00-f6b4-11e9-9e16-6e9ba6117221.png">



**After**

<img width="1346" alt="Screen Shot 2019-10-24 at 23 09 50" src="https://user-images.githubusercontent.com/11751745/67505102-d7686500-f6b4-11e9-9e44-1286890ee22a.png">
